### PR TITLE
Adds HTLC tests from chatch/hashed-timelock-contract-ethereum

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@ Next, create the transaction manager:
 
     -Run node manager-cli.js which will launch the manager-cli prompt
     -Run create_manager --pk <private_key> --p <chat_port> --ta <test_token_address>
-    -Run connect --a <ganache_node_address> 
+    -Run connect --a <ganache_node_address>
 
 Then create two new clients. For each client run:
 
     -Start the client via node client-cli.js which launches the prompt
     -Run create_client --pk <private_key> --ta <test_token_address> --t <test_id> (Set test_id = 0 for first client and test_id = 1 for second client)
     -Run connect --a <ganache_node_address>
-    -Run start_transaction --t <type = WEI_TO_COIN | COIN_TO_WEI> --w <wei_amount> --m <manager_address> 
+    -Run start_transaction --t <type = WEI_TO_COIN | COIN_TO_WEI> --w <wei_amount> --m <manager_address>
 
 Once you run start_tranasction from both clients, you should see the transaction go through each step and complete
+
+Smart Contract Testing:
+
+To test the HTLC contracts, make sure ganache is running and then run truffle test

--- a/contracts/ASEANToken.sol
+++ b/contracts/ASEANToken.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.4.23;
+
+import "zeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
+
+/**
+ * A basic token for testing the HashedTimelockERC20.
+ */
+contract ASEANToken is StandardToken {
+    string public constant name = "ASEAN Token";
+    string public constant symbol = "ASEAN";
+    uint8 public constant decimals = 18;
+
+    constructor(uint _initialBalance) public {
+        balances[msg.sender] = _initialBalance;
+    }
+}

--- a/contracts/TestToken.sol
+++ b/contracts/TestToken.sol
@@ -9,5 +9,5 @@ contract TestToken is StandardToken{
         for(uint i = 0;i < initialRecipients.length;i++){
             balances[initialRecipients[i]] = 10;
         }
-    }   
+    }
 }

--- a/test/helper/assert.js
+++ b/test/helper/assert.js
@@ -1,0 +1,16 @@
+if (!global.assert) global.assert = require('chai').assert
+
+const assertEqualBN = (actual, expected, msg = 'numbers not equal') => {
+  assert.isTrue(
+    actual.equals(expected),
+    `
+\tmsg: ${msg}
+\tactual: ${actual.toString()}
+\texpected: ${expected.toString()}
+`
+  )
+}
+
+module.exports = {
+  assertEqualBN: assertEqualBN,
+}

--- a/test/helper/utils.js
+++ b/test/helper/utils.js
@@ -1,0 +1,73 @@
+const crypto = require('crypto')
+
+// Format required for sending bytes through eth client:
+//  - hex string representation
+//  - prefixed with 0x
+const bufToStr = b => '0x' + b.toString('hex')
+
+const sha256 = x =>
+  crypto
+    .createHash('sha256')
+    .update(x)
+    .digest()
+
+const random32 = () => crypto.randomBytes(32)
+
+const isSha256Hash = hashStr => /^0x[0-9a-f]{64}$/i.test(hashStr)
+
+const newSecretHashPair = () => {
+  const secret = random32()
+  const hash = sha256(secret)
+  return {
+    secret: bufToStr(secret),
+    hash: bufToStr(hash),
+  }
+}
+
+const nowSeconds = () => Math.floor(Date.now() / 1000)
+
+const gasPrice = 100000000000 // truffle fixed gas price
+const txGas = txReceipt => txReceipt.receipt.gasUsed * gasPrice
+const txLoggedArgs = txReceipt => txReceipt.logs[0].args
+const txContractId = txReceipt => txLoggedArgs(txReceipt).contractId
+
+const htlcArrayToObj = c => {
+  return {
+    sender: c[0],
+    receiver: c[1],
+    amount: c[2],
+    hashlock: c[3],
+    timelock: c[4],
+    withdrawn: c[5],
+    refunded: c[6],
+    preimage: c[7],
+  }
+}
+
+const htlcERC20ArrayToObj = c => {
+  return {
+    sender: c[0],
+    receiver: c[1],
+    token: c[2],
+    amount: c[3],
+    hashlock: c[4],
+    timelock: c[5],
+    withdrawn: c[6],
+    refunded: c[7],
+    preimage: c[8],
+  }
+}
+
+module.exports = {
+  bufToStr: bufToStr,
+  htlcArrayToObj: htlcArrayToObj,
+  htlcERC20ArrayToObj: htlcERC20ArrayToObj,
+  isSha256Hash: isSha256Hash,
+  newSecretHashPair: newSecretHashPair,
+  nowSeconds: nowSeconds,
+  random32: random32,
+  sha256: sha256,
+  txContractId: txContractId,
+  txGas: txGas,
+  txLoggedArgs: txLoggedArgs,
+}

--- a/test/htlc.js
+++ b/test/htlc.js
@@ -1,0 +1,302 @@
+const assertEqualBN = require('./helper/assert').assertEqualBN
+const utils = require('./helper/utils')
+const bufToStr = utils.bufToStr
+const htlcArrayToObj = utils.htlcArrayToObj
+const isSha256Hash = utils.isSha256Hash
+const newSecretHashPair = utils.newSecretHashPair
+const nowSeconds = utils.nowSeconds
+const random32 = utils.random32
+const txContractId = utils.txContractId
+const txGas = utils.txGas
+const txLoggedArgs = utils.txLoggedArgs
+
+const HashedTimelock = artifacts.require('./HashedTimelock.sol')
+
+const REQUIRE_FAILED_MSG = 'VM Exception while processing transaction: revert'
+
+const hourSeconds = 3600
+const timeLock1Hour = nowSeconds() + hourSeconds
+const oneFinney = web3.toWei(1, 'finney')
+
+contract('HashedTimelock', accounts => {
+  const sender = accounts[1]
+  const receiver = accounts[2]
+
+  it('newContract() should create new contract and store correct details', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.deployed()
+    const txReceipt = await htlc.newContract(
+      receiver,
+      hashPair.hash,
+      timeLock1Hour,
+      {
+        from: sender,
+        value: oneFinney,
+      }
+    )
+    const logArgs = txLoggedArgs(txReceipt)
+
+    const contractId = logArgs.contractId
+    assert(isSha256Hash(contractId))
+
+    assert.equal(logArgs.sender, sender)
+    assert.equal(logArgs.receiver, receiver)
+    assert.equal(logArgs.amount, oneFinney)
+    assert.equal(logArgs.hashlock, hashPair.hash)
+    assert.equal(logArgs.timelock, timeLock1Hour)
+
+    const contractArr = await htlc.getContract.call(contractId)
+    const contract = htlcArrayToObj(contractArr)
+    assert.equal(contract.sender, sender)
+    assert.equal(contract.receiver, receiver)
+    assert.equal(contract.amount, oneFinney)
+    assert.equal(contract.hashlock, hashPair.hash)
+    assert.equal(contract.timelock.toNumber(), timeLock1Hour)
+    assert.isFalse(contract.withdrawn)
+    assert.isFalse(contract.refunded)
+    assert.equal(
+      contract.preimage,
+      '0x0000000000000000000000000000000000000000000000000000000000000000'
+    )
+  })
+
+  it('newContract() should fail when no ETH sent', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.deployed()
+    try {
+      await htlc.newContract(receiver, hashPair.hash, timeLock1Hour, {
+        from: sender,
+        value: 0,
+      })
+      assert.fail('expected failure due to 0 value transferred')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' msg.value must be > 0')
+    }
+  })
+
+  it('newContract() should fail with timelocks in the past', async () => {
+    const hashPair = newSecretHashPair()
+    const pastTimelock = nowSeconds() - 1
+    const htlc = await HashedTimelock.deployed()
+    try {
+      await htlc.newContract(receiver, hashPair.hash, pastTimelock, {
+        from: sender,
+        value: oneFinney,
+      })
+
+      assert.fail('expected failure due past timelock')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' timelock time must be in the future')
+    }
+  })
+
+  it('newContract() should reject a duplicate contract request', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.deployed()
+    await htlc.newContract(receiver, hashPair.hash, timeLock1Hour, {
+      from: sender,
+      value: oneFinney,
+    })
+
+    // now call again with the exact same parameters
+    try {
+      await htlc.newContract(receiver, hashPair.hash, timeLock1Hour, {
+        from: sender,
+        value: oneFinney,
+      })
+      assert.fail('expected failure due to duplicate request')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG)
+    }
+  })
+
+  it('withdraw() should send receiver funds when given the correct secret preimage', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.deployed()
+    const newContractTx = await htlc.newContract(
+      receiver,
+      hashPair.hash,
+      timeLock1Hour,
+      {
+        from: sender,
+        value: oneFinney,
+      }
+    )
+
+    const contractId = txContractId(newContractTx)
+    const receiverBalBefore = web3.eth.getBalance(receiver)
+
+    // receiver calls withdraw with the secret to get the funds
+    const withdrawTx = await htlc.withdraw(contractId, hashPair.secret, {
+      from: receiver,
+    })
+
+    // Check contract funds are now at the receiver address
+    const expectedBal = receiverBalBefore
+      .plus(oneFinney)
+      .minus(txGas(withdrawTx))
+    assertEqualBN(
+      web3.eth.getBalance(receiver),
+      expectedBal,
+      "receiver balance doesn't match"
+    )
+    const contractArr = await htlc.getContract.call(contractId)
+    const contract = htlcArrayToObj(contractArr)
+    assert.isTrue(contract.withdrawn) // withdrawn set
+    assert.isFalse(contract.refunded) // refunded still false
+    assert.equal(contract.preimage, hashPair.secret)
+  })
+
+  it('withdraw() should fail if preimage does not hash to hashX', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.deployed()
+    const newContractTx = await htlc.newContract(
+      receiver,
+      hashPair.hash,
+      timeLock1Hour,
+      {
+        from: sender,
+        value: oneFinney,
+      }
+    )
+    const contractId = txContractId(newContractTx)
+
+    // receiver calls withdraw with an invalid secret
+    const wrongSecret = bufToStr(random32())
+    try {
+      await htlc.withdraw(contractId, wrongSecret, {from: receiver})
+      assert.fail('expected failure due to 0 value transferred')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' hashlock hash does not match')
+    }
+  })
+
+  it('withdraw() should fail if caller is not the receiver', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.deployed()
+    const newContractTx = await htlc.newContract(
+      receiver,
+      hashPair.hash,
+      timeLock1Hour,
+      {
+        from: sender,
+        value: oneFinney,
+      }
+    )
+    const contractId = txContractId(newContractTx)
+    const someGuy = accounts[4]
+    try {
+      await htlc.withdraw(contractId, hashPair.secret, {from: someGuy})
+      assert.fail('expected failure due to wrong receiver')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' withdrawable: not receiver')
+    }
+  })
+
+  it('withdraw() should fail after timelock expiry', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.new()
+    const timelock1Second = nowSeconds() + 1
+
+    const newContractTx = await htlc.newContract(
+      receiver,
+      hashPair.hash,
+      timelock1Second,
+      {
+        from: sender,
+        value: oneFinney,
+      }
+    )
+    const contractId = txContractId(newContractTx)
+
+    // wait one second so we move past the timelock time
+    return new Promise((resolve, reject) =>
+      setTimeout(async () => {
+        // attempt to withdraw and check that it is not allowed
+        try {
+          await htlc.withdraw(contractId, hashPair.secret, {from: receiver})
+          reject(
+            new Error('expected failure due to withdraw after timelock expired')
+          )
+        } catch (err) {
+          assert.equal(err.message, REQUIRE_FAILED_MSG +
+            ' withdrawable: timelock time must be in the future')
+          resolve()
+        }
+      }, 1000)
+    )
+  })
+
+  it('refund() should pass after timelock expiry', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.new()
+    const timelock1Second = nowSeconds() + 1
+
+    const newContractTx = await htlc.newContract(
+      receiver,
+      hashPair.hash,
+      timelock1Second,
+      {
+        from: sender,
+        value: oneFinney,
+      }
+    )
+    const contractId = txContractId(newContractTx)
+
+    // wait one second so we move past the timelock time
+    return new Promise((resolve, reject) =>
+      setTimeout(async () => {
+        try {
+          const balBefore = web3.eth.getBalance(sender)
+          const tx = await htlc.refund(contractId, {from: sender})
+          // Check contract funds are now at the senders address
+          const expectedBal = balBefore.plus(oneFinney).minus(txGas(tx))
+          assertEqualBN(
+            web3.eth.getBalance(sender),
+            expectedBal,
+            "sender balance doesn't match"
+          )
+          const contract = await htlc.getContract.call(contractId)
+          assert.isTrue(contract[6]) // refunded set
+          assert.isFalse(contract[5]) // withdrawn still false
+          resolve()
+        } catch (err) {
+          reject(err)
+        }
+      }, 1000)
+    )
+  })
+
+  it('refund() should fail before the timelock expiry', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.deployed()
+    const newContractTx = await htlc.newContract(
+      receiver,
+      hashPair.hash,
+      timeLock1Hour,
+      {
+        from: sender,
+        value: oneFinney,
+      }
+    )
+    const contractId = txContractId(newContractTx)
+    try {
+      await htlc.refund(contractId, {from: sender})
+      assert.fail('expected failure due to timelock')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' refundable: timelock not yet passed')
+    }
+  })
+
+  it("getContract() returns empty record when contract doesn't exist", async () => {
+    const htlc = await HashedTimelock.deployed()
+    const contract = await htlc.getContract.call('0xabcdef')
+    const sender = contract[0]
+    assert.equal(Number(sender), 0)
+  })
+})

--- a/test/htlcERC20.js
+++ b/test/htlcERC20.js
@@ -1,0 +1,340 @@
+const assertEqualBN = require('./helper/assert').assertEqualBN
+const utils = require('./helper/utils')
+const bufToStr = utils.bufToStr
+const htlcERC20ArrayToObj = utils.htlcERC20ArrayToObj
+const isSha256Hash = utils.isSha256Hash
+const newSecretHashPair = utils.newSecretHashPair
+const nowSeconds = utils.nowSeconds
+const random32 = utils.random32
+const txContractId = utils.txContractId
+const txGas = utils.txGas
+const txLoggedArgs = utils.txLoggedArgs
+
+const HashedTimelockERC20 = artifacts.require('./HashedTimelockERC20.sol')
+const TestToken = artifacts.require('./ASEANToken.sol')
+
+const REQUIRE_FAILED_MSG = 'VM Exception while processing transaction: revert'
+
+// some testing data
+const hourSeconds = 3600
+const timeLock1Hour = nowSeconds() + hourSeconds
+const tokenAmount = 5
+
+contract('HashedTimelockERC20', accounts => {
+  const sender = accounts[1]
+  const receiver = accounts[2]
+  const tokenSupply = 1000
+  const senderInitialBalance = 100
+
+  let htlc
+  let token
+
+  const assertTokenBal = async (addr, tokenAmount, msg) => {
+    assertEqualBN(
+      await token.balanceOf.call(addr),
+      tokenAmount,
+      msg ? msg : 'wrong token balance'
+    )
+  }
+
+  before(async () => {
+    htlc = await HashedTimelockERC20.new()
+    token = await TestToken.new(tokenSupply)
+    await token.transfer(sender, senderInitialBalance)
+    await assertTokenBal(
+      sender,
+      senderInitialBalance,
+      'balance not transferred in before()'
+    )
+  })
+
+  it('newContract() should create new contract and store correct details', async () => {
+    const hashPair = newSecretHashPair()
+    const newContractTx = await newContract({
+      hashlock: hashPair.hash,
+    })
+
+    // check token balances
+    assertTokenBal(sender, senderInitialBalance - tokenAmount)
+    assertTokenBal(htlc.address, tokenAmount)
+
+    // check event logs
+    const logArgs = txLoggedArgs(newContractTx)
+
+    const contractId = logArgs.contractId
+    assert(isSha256Hash(contractId))
+
+    assert.equal(logArgs.sender, sender)
+    assert.equal(logArgs.receiver, receiver)
+    assert.equal(logArgs.tokenContract, token.address)
+    assert.equal(logArgs.amount.toNumber(), tokenAmount)
+    assert.equal(logArgs.hashlock, hashPair.hash)
+    assert.equal(logArgs.timelock, timeLock1Hour)
+
+    // check htlc record
+    const contractArr = await htlc.getContract.call(contractId)
+    const contract = htlcERC20ArrayToObj(contractArr)
+    assert.equal(contract.sender, sender)
+    assert.equal(contract.receiver, receiver)
+    assert.equal(contract.token, token.address)
+    assert.equal(contract.amount.toNumber(), tokenAmount)
+    assert.equal(contract.hashlock, hashPair.hash)
+    assert.equal(contract.timelock.toNumber(), timeLock1Hour)
+    assert.isFalse(contract.withdrawn)
+    assert.isFalse(contract.refunded)
+    assert.equal(
+      contract.preimage,
+      '0x0000000000000000000000000000000000000000000000000000000000000000'
+    )
+  })
+
+  it('newContract() should fail when no token transfer approved', async () => {
+    await token.approve(htlc.address, 0, {from: sender}) // ensure 0
+    await newContractExpectFailure(
+      'expected failure due to no tokens approved',
+      ' token allowance must be >= amount'
+    )
+  })
+
+  it('newContract() should fail when token amount is 0', async () => {
+    // approve htlc for one token but send amount as 0
+    await token.approve(htlc.address, 1, {from: sender})
+    await newContractExpectFailure(
+      'expected failure due to 0 token amount',
+      ' token amount must be > 0',
+      {amount: 0}
+    )
+  })
+
+  it('newContract() should fail when tokens approved for some random account', async () => {
+    // approve htlc for different account to the htlc contract
+    await token.approve(htlc.address, 0, {from: sender}) // ensure 0
+    await token.approve(accounts[9], tokenAmount, {from: sender})
+    await newContractExpectFailure(
+      'expected failure due to wrong approval',
+      ' token allowance must be >= amount'
+    )
+  })
+
+  it('newContract() should fail when the timelock is in the past', async () => {
+    const pastTimelock = nowSeconds() - 2
+    await token.approve(htlc.address, tokenAmount, {from: sender})
+    await newContractExpectFailure(
+      'expected failure due to timelock in the past',
+      ' timelock time must be in the future',
+      {timelock: pastTimelock}
+    )
+  })
+
+  it('newContract() should reject a duplicate contract request', async () => {
+    const hashlock = newSecretHashPair().hash
+    const timelock = timeLock1Hour + 5
+    const balBefore = await token.balanceOf(htlc.address)
+
+    await newContract({hashlock: hashlock, timelock: timelock})
+    await assertTokenBal(
+      htlc.address,
+      balBefore.plus(tokenAmount),
+      'tokens not transfered to htlc contract'
+    )
+
+    // now attempt to create another with the exact same parameters
+    await newContractExpectFailure(
+      'expected failure due to duplicate contract details',
+      ' token allowance must be >= amount',
+      {timelock, hashlock}
+    )
+  })
+
+  it('withdraw() should send receiver funds when given the correct secret preimage', async () => {
+    const hashPair = newSecretHashPair()
+    const newContractTx = await newContract({hashlock: hashPair.hash})
+    const contractId = txContractId(newContractTx)
+
+    // receiver calls withdraw with the secret to claim the tokens
+    await htlc.withdraw(contractId, hashPair.secret, {
+      from: receiver,
+    })
+
+    // Check tokens now owned by the receiver
+    await assertTokenBal(
+      receiver,
+      tokenAmount,
+      `receiver doesn't not own ${tokenAmount} tokens`
+    )
+
+    const contractArr = await htlc.getContract.call(contractId)
+    const contract = htlcERC20ArrayToObj(contractArr)
+    assert.isTrue(contract.withdrawn) // withdrawn set
+    assert.isFalse(contract.refunded) // refunded still false
+    assert.equal(contract.preimage, hashPair.secret)
+  })
+
+  it('withdraw() should fail if preimage does not hash to hashX', async () => {
+    const newContractTx = await newContract({})
+    const contractId = txContractId(newContractTx)
+
+    // receiver calls withdraw with an invalid secret
+    const wrongSecret = bufToStr(random32())
+    try {
+      await htlc.withdraw(contractId, wrongSecret, {from: receiver})
+      assert.fail('expected failure due to 0 value transferred')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' hashlock hash does not match')
+    }
+  })
+
+  it('withdraw() should fail if caller is not the receiver ', async () => {
+    const hashPair = newSecretHashPair()
+    await token.approve(htlc.address, tokenAmount, {from: sender})
+    const newContractTx = await newContract({
+      hashlock: hashPair.hash,
+    })
+    const contractId = txContractId(newContractTx)
+    const someGuy = accounts[4]
+    try {
+      await htlc.withdraw(contractId, hashPair.secret, {from: someGuy})
+      assert.fail('expected failure due to wrong receiver')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' withdrawable: not receiver')
+    }
+  })
+
+  it('withdraw() should fail after timelock expiry', async () => {
+    const hashPair = newSecretHashPair()
+    const curBlkTime = web3.eth.getBlock('latest').timestamp
+    const timelock2Seconds = curBlkTime + 2
+
+    const newContractTx = await newContract({
+      hashlock: hashPair.hash,
+      timelock: timelock2Seconds,
+    })
+    const contractId = txContractId(newContractTx)
+
+    // wait one second so we move past the timelock time
+    return new Promise((resolve, reject) => {
+      setTimeout(async () => {
+        // attempt to withdraw and check that it is not allowed
+        try {
+          await htlc.withdraw(contractId, hashPair.secret, {from: receiver})
+          reject(
+            new Error('expected failure due to withdraw after timelock expired')
+          )
+        } catch (err) {
+          assert.equal(err.message, REQUIRE_FAILED_MSG +
+            ' withdrawable: timelock time must be in the future')
+          resolve({message: 'success'})
+        }
+      }, 2000)
+    })
+  })
+
+  it('refund() should pass after timelock expiry', async () => {
+    const hashPair = newSecretHashPair()
+    const curBlkTime = web3.eth.getBlock('latest').timestamp
+    const timelock2Seconds = curBlkTime + 2
+
+    await token.approve(htlc.address, tokenAmount, {from: sender})
+    const newContractTx = await newContract({
+      timelock: timelock2Seconds,
+      hashlock: hashPair.hash,
+    })
+    const contractId = txContractId(newContractTx)
+
+    // wait one second so we move past the timelock time
+    return new Promise((resolve, reject) =>
+      setTimeout(async () => {
+        try {
+          // attempt to get the refund now we've moved past the timelock time
+          const balBefore = await token.balanceOf(sender)
+          await htlc.refund(contractId, {from: sender})
+
+          // Check tokens returned to the sender
+          await assertTokenBal(
+            sender,
+            balBefore.plus(tokenAmount),
+            `sender balance unexpected`
+          )
+
+          const contractArr = await htlc.getContract.call(contractId)
+          const contract = htlcERC20ArrayToObj(contractArr)
+          assert.isTrue(contract.refunded)
+          assert.isFalse(contract.withdrawn)
+          resolve()
+        } catch (err) {
+          reject(err)
+        }
+      }, 2000)
+    )
+  })
+
+  it('refund() should fail before the timelock expiry', async () => {
+    const newContractTx = await newContract()
+    const contractId = txContractId(newContractTx)
+    try {
+      await htlc.refund(contractId, {from: sender})
+      assert.fail('expected failure due to timelock')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' refundable: timelock not yet passed')
+    }
+  })
+
+  it("getContract() returns empty record when contract doesn't exist", async () => {
+    const htlc = await HashedTimelockERC20.deployed()
+    const contract = await htlc.getContract.call('0xabcdef')
+    const sender = contract[0]
+    assert.equal(Number(sender), 0)
+  })
+
+  /*
+   * Helper for newContract() calls, does the ERC20 approve before calling
+   */
+  const newContract = async ({
+    timelock = timeLock1Hour,
+    hashlock = newSecretHashPair().hash,
+  } = {}) => {
+    await token.approve(htlc.address, tokenAmount, {from: sender})
+    return htlc.newContract(
+      receiver,
+      hashlock,
+      timelock,
+      token.address,
+      tokenAmount,
+      {
+        from: sender,
+      }
+    )
+  }
+
+  /*
+   * Helper for newContract() when expecting failure
+   */
+  const newContractExpectFailure = async (
+    shouldFailMsg,
+    expectedFailReason,
+    {
+      receiverAddr = receiver,
+      amount = tokenAmount,
+      timelock = timeLock1Hour,
+    } = {}
+  ) => {
+    try {
+      await htlc.newContract(
+        receiverAddr,
+        newSecretHashPair().hash,
+        timelock,
+        token.address,
+        amount,
+        {
+          from: sender,
+        }
+      )
+      assert.fail(shouldFailMsg)
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG + expectedFailReason)
+    }
+  }
+})


### PR DESCRIPTION
Tests are modified slightly to make them compatible with our setup but are functionally the same as in https://github.com/chatch/hashed-timelock-contract-ethereum.git

Now that we have smart contract testing set up, we can extend these tests as needed in the future