### PR TITLE
Protocol Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@ Next, create the transaction manager:
 
     -Run node manager-cli.js which will launch the manager-cli prompt
     -Run create_manager --pk <private_key> --p <chat_port> --ta <test_token_address>
-    -Run connect --a <ganache_node_address> 
+    -Run connect --a <ganache_node_address>
 
 Then create two new clients. For each client run:
 
     -Start the client via node client-cli.js which launches the prompt
     -Run create_client --pk <private_key> --ta <test_token_address> --t <test_id> (Set test_id = 0 for first client and test_id = 1 for second client)
     -Run connect --a <ganache_node_address>
-    -Run start_transaction --t <type = WEI_TO_COIN | COIN_TO_WEI> --w <wei_amount> --m <manager_address> 
+    -Run start_transaction --t <type = WEI_TO_COIN | COIN_TO_WEI> --w <wei_amount> --m <manager_address>
 
 Once you run start_tranasction from both clients, you should see the transaction go through each step and complete
+
+Smart Contract Testing:
+
+To test the HTLC contracts, make sure ganache is running and then run truffle test

--- a/contracts/ASEANToken.sol
+++ b/contracts/ASEANToken.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.4.23;
+
+import "zeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
+
+/**
+ * A basic token for testing the HashedTimelockERC20.
+ */
+contract ASEANToken is StandardToken {
+    string public constant name = "ASEAN Token";
+    string public constant symbol = "ASEAN";
+    uint8 public constant decimals = 18;
+
+    constructor(uint _initialBalance) public {
+        balances[msg.sender] = _initialBalance;
+    }
+}

--- a/contracts/TestToken.sol
+++ b/contracts/TestToken.sol
@@ -9,5 +9,5 @@ contract TestToken is StandardToken{
         for(uint i = 0;i < initialRecipients.length;i++){
             balances[initialRecipients[i]] = 10;
         }
-    }   
+    }
 }

--- a/main1.js
+++ b/main1.js
@@ -1,0 +1,4 @@
+var Manager = require("./src/manager/manager");
+
+var manager = new Manager("0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d",3000, '0xc89ce4735882c9f0f0fe26686c53074e09b0d550');
+manager.connectToNode("http://localhost:8545");

--- a/main2.js
+++ b/main2.js
@@ -1,0 +1,5 @@
+var Client = require("./src/client/client");
+
+var node1 = new Client('0x6cbed15c793ce57650b9877cf6fa156fbef513c4e6134f022a85b1ffdd59b2a1', '0xc89ce4735882c9f0f0fe26686c53074e09b0d550');
+node1.connectToNode("http://localhost:8545");
+node1.handleTransaction("http://localhost:3000", 0, 10, 1);

--- a/main3.js
+++ b/main3.js
@@ -1,0 +1,5 @@
+var Client = require("./src/client/client");
+
+var node2 = new Client('0x6370fd033278c143179d81c5526140625662b8daa446c22ee2d73db3707e620c', '0xc89ce4735882c9f0f0fe26686c53074e09b0d550');
+node2.connectToNode("http://localhost:8545");
+node2.handleTransaction("http://localhost:3000", 1, 10, 1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,15 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "assert-diff": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/assert-diff/-/assert-diff-2.0.3.tgz",
+      "integrity": "sha512-TAPT9BmNP3384kP9jdkgRIYdddSO2hG3oG8B5+hoTd2khGC0XrM8ZT+FEkTr4kFFhzDuUveGtvNGcXD63qP6Mw==",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "json-diff": "0.5.2"
+      }
+    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -180,8 +189,9 @@
       }
     },
     "bignumber.js": {
-      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-      "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.0.1.tgz",
+      "integrity": "sha512-zAySveTJXkgLYCBi0b14xzfnOs+f3G6x36I8w2a1+PFQpWk/dp0mI0F+ZZK2bu+3ELewDcSyP+Cfq++NcHX7sg=="
     },
     "bindings": {
       "version": "1.3.0",
@@ -438,6 +448,14 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "cli-color": {
+      "version": "0.1.7",
+      "resolved": "http://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
+      "integrity": "sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=",
+      "requires": {
+        "es5-ext": "0.8.x"
       }
     },
     "cli-cursor": {
@@ -764,6 +782,14 @@
         "randombytes": "^2.0.0"
       }
     },
+    "difflib": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
+      "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
+      "requires": {
+        "heap": ">= 0.2.0"
+      }
+    },
     "dom-walk": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
@@ -777,6 +803,14 @@
         "browserify-aes": "^1.0.6",
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4"
+      }
+    },
+    "dreamopt": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
+      "integrity": "sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=",
+      "requires": {
+        "wordwrap": ">=0.0.2"
       }
     },
     "duplexer3": {
@@ -895,6 +929,11 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "es5-ext": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz",
+      "integrity": "sha1-q6jZ4ZQ6iVrJaDemKjmz9V7NlKs="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -1435,6 +1474,11 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
+    "heap": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -1668,6 +1712,16 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-diff": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.5.2.tgz",
+      "integrity": "sha512-N7oapTQdD4rLMUtA7d1HATCPY/BpHuSNL1mhvIuoS0u5NideDvyR+gB/ntXB7ejFz/LM0XzPLNUJQcC68n5sBw==",
+      "requires": {
+        "cli-color": "~0.1.6",
+        "difflib": "~0.2.1",
+        "dreamopt": "~0.6.0"
+      }
     },
     "json-schema": {
       "version": "0.2.3",
@@ -3117,6 +3171,10 @@
         "web3": "^0.20.1"
       },
       "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+        },
         "web3": {
           "version": "0.20.7",
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
@@ -3127,6 +3185,12 @@
             "utf8": "^2.1.1",
             "xhr2-cookies": "^1.1.0",
             "xmlhttprequest": "*"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+            }
           }
         }
       }
@@ -3142,6 +3206,10 @@
         "web3": "^0.20.1"
       },
       "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+        },
         "web3": {
           "version": "0.20.7",
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
@@ -3152,6 +3220,12 @@
             "utf8": "^2.1.1",
             "xhr2-cookies": "^1.1.0",
             "xmlhttprequest": "*"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+            }
           }
         }
       }
@@ -3688,6 +3762,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
       "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "author": "Daniel Engel",
   "license": "ISC",
   "dependencies": {
+    "assert-diff": "^2.0.3",
+    "bignumber.js": "^8.0.1",
     "buffer-xor": "^2.0.2",
     "ethereumjs-tx": "^1.3.7",
     "ethers": "^4.0.7",

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -1,3 +1,5 @@
+var web3 = require('web3');
+
 var MsgTypeEnum ={
     INIT : 0,
     POOL_HASHES : 1,
@@ -23,9 +25,64 @@ function createMsg(txId,msgType,txType,from,data){
     }
 }
 
+function isString(s) {
+    return typeof(s) === 'string' || s instanceof String;
+}
+
+function contractToObject(contractArray) {
+
+  var contractObject = {};
+
+  for (i = 0; i < contractArray.length; i++) {
+    switch (+i) {
+      case 0:
+        let senderAddress = web3.utils.toChecksumAddress(contractArray[i]);
+        contractObject['sender'] = senderAddress;
+        break;
+      case 1:
+        let receiverAddress = web3.utils.toChecksumAddress(contractArray[i]);
+        contractObject['receiver'] = receiverAddress;
+        break;
+      case 2:
+        if (isString(contractArray[i])) {
+          let tokenAddress = web3.utils.toChecksumAddress(contractArray[i]);
+          contractObject['tokenAddress'] = tokenAddress;
+          var shift = 0;
+          break;
+        } else {
+          contractObject['tokenAddress'] = null;
+          var shift = 1;
+          contractArray.push(null);
+          i++;
+        }
+      case 3:
+        contractObject['amount'] = contractArray[i-shift];
+        break;
+      case 4:
+        contractObject['hashlock'] = contractArray[i-shift];
+        break;
+      case 5:
+        contractObject['timelock'] = contractArray[i-shift];
+        break;
+      case 6:
+        contractObject['withdrawn'] = contractArray[i-shift];
+        break;
+      case 7:
+        contractObject['refunded'] = contractArray[i-shift];
+        break;
+      case 8:
+        contractObject['preImage'] = contractArray[i-shift];
+        break;
+    }
+  }
+
+  return contractObject;
+}
+
 
 module.exports = {
     MsgTypeEnum,
     TxTypeEnum,
-    createMsg
+    createMsg,
+    contractToObject,
 }

--- a/test/helper/assert.js
+++ b/test/helper/assert.js
@@ -1,0 +1,16 @@
+if (!global.assert) global.assert = require('chai').assert
+
+const assertEqualBN = (actual, expected, msg = 'numbers not equal') => {
+  assert.isTrue(
+    actual.equals(expected),
+    `
+\tmsg: ${msg}
+\tactual: ${actual.toString()}
+\texpected: ${expected.toString()}
+`
+  )
+}
+
+module.exports = {
+  assertEqualBN: assertEqualBN,
+}

--- a/test/helper/utils.js
+++ b/test/helper/utils.js
@@ -1,0 +1,73 @@
+const crypto = require('crypto')
+
+// Format required for sending bytes through eth client:
+//  - hex string representation
+//  - prefixed with 0x
+const bufToStr = b => '0x' + b.toString('hex')
+
+const sha256 = x =>
+  crypto
+    .createHash('sha256')
+    .update(x)
+    .digest()
+
+const random32 = () => crypto.randomBytes(32)
+
+const isSha256Hash = hashStr => /^0x[0-9a-f]{64}$/i.test(hashStr)
+
+const newSecretHashPair = () => {
+  const secret = random32()
+  const hash = sha256(secret)
+  return {
+    secret: bufToStr(secret),
+    hash: bufToStr(hash),
+  }
+}
+
+const nowSeconds = () => Math.floor(Date.now() / 1000)
+
+const gasPrice = 100000000000 // truffle fixed gas price
+const txGas = txReceipt => txReceipt.receipt.gasUsed * gasPrice
+const txLoggedArgs = txReceipt => txReceipt.logs[0].args
+const txContractId = txReceipt => txLoggedArgs(txReceipt).contractId
+
+const htlcArrayToObj = c => {
+  return {
+    sender: c[0],
+    receiver: c[1],
+    amount: c[2],
+    hashlock: c[3],
+    timelock: c[4],
+    withdrawn: c[5],
+    refunded: c[6],
+    preimage: c[7],
+  }
+}
+
+const htlcERC20ArrayToObj = c => {
+  return {
+    sender: c[0],
+    receiver: c[1],
+    token: c[2],
+    amount: c[3],
+    hashlock: c[4],
+    timelock: c[5],
+    withdrawn: c[6],
+    refunded: c[7],
+    preimage: c[8],
+  }
+}
+
+module.exports = {
+  bufToStr: bufToStr,
+  htlcArrayToObj: htlcArrayToObj,
+  htlcERC20ArrayToObj: htlcERC20ArrayToObj,
+  isSha256Hash: isSha256Hash,
+  newSecretHashPair: newSecretHashPair,
+  nowSeconds: nowSeconds,
+  random32: random32,
+  sha256: sha256,
+  txContractId: txContractId,
+  txGas: txGas,
+  txLoggedArgs: txLoggedArgs,
+}

--- a/test/htlc.js
+++ b/test/htlc.js
@@ -1,0 +1,302 @@
+const assertEqualBN = require('./helper/assert').assertEqualBN
+const utils = require('./helper/utils')
+const bufToStr = utils.bufToStr
+const htlcArrayToObj = utils.htlcArrayToObj
+const isSha256Hash = utils.isSha256Hash
+const newSecretHashPair = utils.newSecretHashPair
+const nowSeconds = utils.nowSeconds
+const random32 = utils.random32
+const txContractId = utils.txContractId
+const txGas = utils.txGas
+const txLoggedArgs = utils.txLoggedArgs
+
+const HashedTimelock = artifacts.require('./HashedTimelock.sol')
+
+const REQUIRE_FAILED_MSG = 'VM Exception while processing transaction: revert'
+
+const hourSeconds = 3600
+const timeLock1Hour = nowSeconds() + hourSeconds
+const oneFinney = web3.toWei(1, 'finney')
+
+contract('HashedTimelock', accounts => {
+  const sender = accounts[1]
+  const receiver = accounts[2]
+
+  it('newContract() should create new contract and store correct details', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.deployed()
+    const txReceipt = await htlc.newContract(
+      receiver,
+      hashPair.hash,
+      timeLock1Hour,
+      {
+        from: sender,
+        value: oneFinney,
+      }
+    )
+    const logArgs = txLoggedArgs(txReceipt)
+
+    const contractId = logArgs.contractId
+    assert(isSha256Hash(contractId))
+
+    assert.equal(logArgs.sender, sender)
+    assert.equal(logArgs.receiver, receiver)
+    assert.equal(logArgs.amount, oneFinney)
+    assert.equal(logArgs.hashlock, hashPair.hash)
+    assert.equal(logArgs.timelock, timeLock1Hour)
+
+    const contractArr = await htlc.getContract.call(contractId)
+    const contract = htlcArrayToObj(contractArr)
+    assert.equal(contract.sender, sender)
+    assert.equal(contract.receiver, receiver)
+    assert.equal(contract.amount, oneFinney)
+    assert.equal(contract.hashlock, hashPair.hash)
+    assert.equal(contract.timelock.toNumber(), timeLock1Hour)
+    assert.isFalse(contract.withdrawn)
+    assert.isFalse(contract.refunded)
+    assert.equal(
+      contract.preimage,
+      '0x0000000000000000000000000000000000000000000000000000000000000000'
+    )
+  })
+
+  it('newContract() should fail when no ETH sent', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.deployed()
+    try {
+      await htlc.newContract(receiver, hashPair.hash, timeLock1Hour, {
+        from: sender,
+        value: 0,
+      })
+      assert.fail('expected failure due to 0 value transferred')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' msg.value must be > 0')
+    }
+  })
+
+  it('newContract() should fail with timelocks in the past', async () => {
+    const hashPair = newSecretHashPair()
+    const pastTimelock = nowSeconds() - 1
+    const htlc = await HashedTimelock.deployed()
+    try {
+      await htlc.newContract(receiver, hashPair.hash, pastTimelock, {
+        from: sender,
+        value: oneFinney,
+      })
+
+      assert.fail('expected failure due past timelock')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' timelock time must be in the future')
+    }
+  })
+
+  it('newContract() should reject a duplicate contract request', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.deployed()
+    await htlc.newContract(receiver, hashPair.hash, timeLock1Hour, {
+      from: sender,
+      value: oneFinney,
+    })
+
+    // now call again with the exact same parameters
+    try {
+      await htlc.newContract(receiver, hashPair.hash, timeLock1Hour, {
+        from: sender,
+        value: oneFinney,
+      })
+      assert.fail('expected failure due to duplicate request')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG)
+    }
+  })
+
+  it('withdraw() should send receiver funds when given the correct secret preimage', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.deployed()
+    const newContractTx = await htlc.newContract(
+      receiver,
+      hashPair.hash,
+      timeLock1Hour,
+      {
+        from: sender,
+        value: oneFinney,
+      }
+    )
+
+    const contractId = txContractId(newContractTx)
+    const receiverBalBefore = web3.eth.getBalance(receiver)
+
+    // receiver calls withdraw with the secret to get the funds
+    const withdrawTx = await htlc.withdraw(contractId, hashPair.secret, {
+      from: receiver,
+    })
+
+    // Check contract funds are now at the receiver address
+    const expectedBal = receiverBalBefore
+      .plus(oneFinney)
+      .minus(txGas(withdrawTx))
+    assertEqualBN(
+      web3.eth.getBalance(receiver),
+      expectedBal,
+      "receiver balance doesn't match"
+    )
+    const contractArr = await htlc.getContract.call(contractId)
+    const contract = htlcArrayToObj(contractArr)
+    assert.isTrue(contract.withdrawn) // withdrawn set
+    assert.isFalse(contract.refunded) // refunded still false
+    assert.equal(contract.preimage, hashPair.secret)
+  })
+
+  it('withdraw() should fail if preimage does not hash to hashX', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.deployed()
+    const newContractTx = await htlc.newContract(
+      receiver,
+      hashPair.hash,
+      timeLock1Hour,
+      {
+        from: sender,
+        value: oneFinney,
+      }
+    )
+    const contractId = txContractId(newContractTx)
+
+    // receiver calls withdraw with an invalid secret
+    const wrongSecret = bufToStr(random32())
+    try {
+      await htlc.withdraw(contractId, wrongSecret, {from: receiver})
+      assert.fail('expected failure due to 0 value transferred')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' hashlock hash does not match')
+    }
+  })
+
+  it('withdraw() should fail if caller is not the receiver', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.deployed()
+    const newContractTx = await htlc.newContract(
+      receiver,
+      hashPair.hash,
+      timeLock1Hour,
+      {
+        from: sender,
+        value: oneFinney,
+      }
+    )
+    const contractId = txContractId(newContractTx)
+    const someGuy = accounts[4]
+    try {
+      await htlc.withdraw(contractId, hashPair.secret, {from: someGuy})
+      assert.fail('expected failure due to wrong receiver')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' withdrawable: not receiver')
+    }
+  })
+
+  it('withdraw() should fail after timelock expiry', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.new()
+    const timelock1Second = nowSeconds() + 1
+
+    const newContractTx = await htlc.newContract(
+      receiver,
+      hashPair.hash,
+      timelock1Second,
+      {
+        from: sender,
+        value: oneFinney,
+      }
+    )
+    const contractId = txContractId(newContractTx)
+
+    // wait one second so we move past the timelock time
+    return new Promise((resolve, reject) =>
+      setTimeout(async () => {
+        // attempt to withdraw and check that it is not allowed
+        try {
+          await htlc.withdraw(contractId, hashPair.secret, {from: receiver})
+          reject(
+            new Error('expected failure due to withdraw after timelock expired')
+          )
+        } catch (err) {
+          assert.equal(err.message, REQUIRE_FAILED_MSG +
+            ' withdrawable: timelock time must be in the future')
+          resolve()
+        }
+      }, 1000)
+    )
+  })
+
+  it('refund() should pass after timelock expiry', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.new()
+    const timelock1Second = nowSeconds() + 1
+
+    const newContractTx = await htlc.newContract(
+      receiver,
+      hashPair.hash,
+      timelock1Second,
+      {
+        from: sender,
+        value: oneFinney,
+      }
+    )
+    const contractId = txContractId(newContractTx)
+
+    // wait one second so we move past the timelock time
+    return new Promise((resolve, reject) =>
+      setTimeout(async () => {
+        try {
+          const balBefore = web3.eth.getBalance(sender)
+          const tx = await htlc.refund(contractId, {from: sender})
+          // Check contract funds are now at the senders address
+          const expectedBal = balBefore.plus(oneFinney).minus(txGas(tx))
+          assertEqualBN(
+            web3.eth.getBalance(sender),
+            expectedBal,
+            "sender balance doesn't match"
+          )
+          const contract = await htlc.getContract.call(contractId)
+          assert.isTrue(contract[6]) // refunded set
+          assert.isFalse(contract[5]) // withdrawn still false
+          resolve()
+        } catch (err) {
+          reject(err)
+        }
+      }, 1000)
+    )
+  })
+
+  it('refund() should fail before the timelock expiry', async () => {
+    const hashPair = newSecretHashPair()
+    const htlc = await HashedTimelock.deployed()
+    const newContractTx = await htlc.newContract(
+      receiver,
+      hashPair.hash,
+      timeLock1Hour,
+      {
+        from: sender,
+        value: oneFinney,
+      }
+    )
+    const contractId = txContractId(newContractTx)
+    try {
+      await htlc.refund(contractId, {from: sender})
+      assert.fail('expected failure due to timelock')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' refundable: timelock not yet passed')
+    }
+  })
+
+  it("getContract() returns empty record when contract doesn't exist", async () => {
+    const htlc = await HashedTimelock.deployed()
+    const contract = await htlc.getContract.call('0xabcdef')
+    const sender = contract[0]
+    assert.equal(Number(sender), 0)
+  })
+})

--- a/test/htlcERC20.js
+++ b/test/htlcERC20.js
@@ -1,0 +1,340 @@
+const assertEqualBN = require('./helper/assert').assertEqualBN
+const utils = require('./helper/utils')
+const bufToStr = utils.bufToStr
+const htlcERC20ArrayToObj = utils.htlcERC20ArrayToObj
+const isSha256Hash = utils.isSha256Hash
+const newSecretHashPair = utils.newSecretHashPair
+const nowSeconds = utils.nowSeconds
+const random32 = utils.random32
+const txContractId = utils.txContractId
+const txGas = utils.txGas
+const txLoggedArgs = utils.txLoggedArgs
+
+const HashedTimelockERC20 = artifacts.require('./HashedTimelockERC20.sol')
+const TestToken = artifacts.require('./ASEANToken.sol')
+
+const REQUIRE_FAILED_MSG = 'VM Exception while processing transaction: revert'
+
+// some testing data
+const hourSeconds = 3600
+const timeLock1Hour = nowSeconds() + hourSeconds
+const tokenAmount = 5
+
+contract('HashedTimelockERC20', accounts => {
+  const sender = accounts[1]
+  const receiver = accounts[2]
+  const tokenSupply = 1000
+  const senderInitialBalance = 100
+
+  let htlc
+  let token
+
+  const assertTokenBal = async (addr, tokenAmount, msg) => {
+    assertEqualBN(
+      await token.balanceOf.call(addr),
+      tokenAmount,
+      msg ? msg : 'wrong token balance'
+    )
+  }
+
+  before(async () => {
+    htlc = await HashedTimelockERC20.new()
+    token = await TestToken.new(tokenSupply)
+    await token.transfer(sender, senderInitialBalance)
+    await assertTokenBal(
+      sender,
+      senderInitialBalance,
+      'balance not transferred in before()'
+    )
+  })
+
+  it('newContract() should create new contract and store correct details', async () => {
+    const hashPair = newSecretHashPair()
+    const newContractTx = await newContract({
+      hashlock: hashPair.hash,
+    })
+
+    // check token balances
+    assertTokenBal(sender, senderInitialBalance - tokenAmount)
+    assertTokenBal(htlc.address, tokenAmount)
+
+    // check event logs
+    const logArgs = txLoggedArgs(newContractTx)
+
+    const contractId = logArgs.contractId
+    assert(isSha256Hash(contractId))
+
+    assert.equal(logArgs.sender, sender)
+    assert.equal(logArgs.receiver, receiver)
+    assert.equal(logArgs.tokenContract, token.address)
+    assert.equal(logArgs.amount.toNumber(), tokenAmount)
+    assert.equal(logArgs.hashlock, hashPair.hash)
+    assert.equal(logArgs.timelock, timeLock1Hour)
+
+    // check htlc record
+    const contractArr = await htlc.getContract.call(contractId)
+    const contract = htlcERC20ArrayToObj(contractArr)
+    assert.equal(contract.sender, sender)
+    assert.equal(contract.receiver, receiver)
+    assert.equal(contract.token, token.address)
+    assert.equal(contract.amount.toNumber(), tokenAmount)
+    assert.equal(contract.hashlock, hashPair.hash)
+    assert.equal(contract.timelock.toNumber(), timeLock1Hour)
+    assert.isFalse(contract.withdrawn)
+    assert.isFalse(contract.refunded)
+    assert.equal(
+      contract.preimage,
+      '0x0000000000000000000000000000000000000000000000000000000000000000'
+    )
+  })
+
+  it('newContract() should fail when no token transfer approved', async () => {
+    await token.approve(htlc.address, 0, {from: sender}) // ensure 0
+    await newContractExpectFailure(
+      'expected failure due to no tokens approved',
+      ' token allowance must be >= amount'
+    )
+  })
+
+  it('newContract() should fail when token amount is 0', async () => {
+    // approve htlc for one token but send amount as 0
+    await token.approve(htlc.address, 1, {from: sender})
+    await newContractExpectFailure(
+      'expected failure due to 0 token amount',
+      ' token amount must be > 0',
+      {amount: 0}
+    )
+  })
+
+  it('newContract() should fail when tokens approved for some random account', async () => {
+    // approve htlc for different account to the htlc contract
+    await token.approve(htlc.address, 0, {from: sender}) // ensure 0
+    await token.approve(accounts[9], tokenAmount, {from: sender})
+    await newContractExpectFailure(
+      'expected failure due to wrong approval',
+      ' token allowance must be >= amount'
+    )
+  })
+
+  it('newContract() should fail when the timelock is in the past', async () => {
+    const pastTimelock = nowSeconds() - 2
+    await token.approve(htlc.address, tokenAmount, {from: sender})
+    await newContractExpectFailure(
+      'expected failure due to timelock in the past',
+      ' timelock time must be in the future',
+      {timelock: pastTimelock}
+    )
+  })
+
+  it('newContract() should reject a duplicate contract request', async () => {
+    const hashlock = newSecretHashPair().hash
+    const timelock = timeLock1Hour + 5
+    const balBefore = await token.balanceOf(htlc.address)
+
+    await newContract({hashlock: hashlock, timelock: timelock})
+    await assertTokenBal(
+      htlc.address,
+      balBefore.plus(tokenAmount),
+      'tokens not transfered to htlc contract'
+    )
+
+    // now attempt to create another with the exact same parameters
+    await newContractExpectFailure(
+      'expected failure due to duplicate contract details',
+      ' token allowance must be >= amount',
+      {timelock, hashlock}
+    )
+  })
+
+  it('withdraw() should send receiver funds when given the correct secret preimage', async () => {
+    const hashPair = newSecretHashPair()
+    const newContractTx = await newContract({hashlock: hashPair.hash})
+    const contractId = txContractId(newContractTx)
+
+    // receiver calls withdraw with the secret to claim the tokens
+    await htlc.withdraw(contractId, hashPair.secret, {
+      from: receiver,
+    })
+
+    // Check tokens now owned by the receiver
+    await assertTokenBal(
+      receiver,
+      tokenAmount,
+      `receiver doesn't not own ${tokenAmount} tokens`
+    )
+
+    const contractArr = await htlc.getContract.call(contractId)
+    const contract = htlcERC20ArrayToObj(contractArr)
+    assert.isTrue(contract.withdrawn) // withdrawn set
+    assert.isFalse(contract.refunded) // refunded still false
+    assert.equal(contract.preimage, hashPair.secret)
+  })
+
+  it('withdraw() should fail if preimage does not hash to hashX', async () => {
+    const newContractTx = await newContract({})
+    const contractId = txContractId(newContractTx)
+
+    // receiver calls withdraw with an invalid secret
+    const wrongSecret = bufToStr(random32())
+    try {
+      await htlc.withdraw(contractId, wrongSecret, {from: receiver})
+      assert.fail('expected failure due to 0 value transferred')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' hashlock hash does not match')
+    }
+  })
+
+  it('withdraw() should fail if caller is not the receiver ', async () => {
+    const hashPair = newSecretHashPair()
+    await token.approve(htlc.address, tokenAmount, {from: sender})
+    const newContractTx = await newContract({
+      hashlock: hashPair.hash,
+    })
+    const contractId = txContractId(newContractTx)
+    const someGuy = accounts[4]
+    try {
+      await htlc.withdraw(contractId, hashPair.secret, {from: someGuy})
+      assert.fail('expected failure due to wrong receiver')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' withdrawable: not receiver')
+    }
+  })
+
+  it('withdraw() should fail after timelock expiry', async () => {
+    const hashPair = newSecretHashPair()
+    const curBlkTime = web3.eth.getBlock('latest').timestamp
+    const timelock2Seconds = curBlkTime + 2
+
+    const newContractTx = await newContract({
+      hashlock: hashPair.hash,
+      timelock: timelock2Seconds,
+    })
+    const contractId = txContractId(newContractTx)
+
+    // wait one second so we move past the timelock time
+    return new Promise((resolve, reject) => {
+      setTimeout(async () => {
+        // attempt to withdraw and check that it is not allowed
+        try {
+          await htlc.withdraw(contractId, hashPair.secret, {from: receiver})
+          reject(
+            new Error('expected failure due to withdraw after timelock expired')
+          )
+        } catch (err) {
+          assert.equal(err.message, REQUIRE_FAILED_MSG +
+            ' withdrawable: timelock time must be in the future')
+          resolve({message: 'success'})
+        }
+      }, 2000)
+    })
+  })
+
+  it('refund() should pass after timelock expiry', async () => {
+    const hashPair = newSecretHashPair()
+    const curBlkTime = web3.eth.getBlock('latest').timestamp
+    const timelock2Seconds = curBlkTime + 2
+
+    await token.approve(htlc.address, tokenAmount, {from: sender})
+    const newContractTx = await newContract({
+      timelock: timelock2Seconds,
+      hashlock: hashPair.hash,
+    })
+    const contractId = txContractId(newContractTx)
+
+    // wait one second so we move past the timelock time
+    return new Promise((resolve, reject) =>
+      setTimeout(async () => {
+        try {
+          // attempt to get the refund now we've moved past the timelock time
+          const balBefore = await token.balanceOf(sender)
+          await htlc.refund(contractId, {from: sender})
+
+          // Check tokens returned to the sender
+          await assertTokenBal(
+            sender,
+            balBefore.plus(tokenAmount),
+            `sender balance unexpected`
+          )
+
+          const contractArr = await htlc.getContract.call(contractId)
+          const contract = htlcERC20ArrayToObj(contractArr)
+          assert.isTrue(contract.refunded)
+          assert.isFalse(contract.withdrawn)
+          resolve()
+        } catch (err) {
+          reject(err)
+        }
+      }, 2000)
+    )
+  })
+
+  it('refund() should fail before the timelock expiry', async () => {
+    const newContractTx = await newContract()
+    const contractId = txContractId(newContractTx)
+    try {
+      await htlc.refund(contractId, {from: sender})
+      assert.fail('expected failure due to timelock')
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG +
+        ' refundable: timelock not yet passed')
+    }
+  })
+
+  it("getContract() returns empty record when contract doesn't exist", async () => {
+    const htlc = await HashedTimelockERC20.deployed()
+    const contract = await htlc.getContract.call('0xabcdef')
+    const sender = contract[0]
+    assert.equal(Number(sender), 0)
+  })
+
+  /*
+   * Helper for newContract() calls, does the ERC20 approve before calling
+   */
+  const newContract = async ({
+    timelock = timeLock1Hour,
+    hashlock = newSecretHashPair().hash,
+  } = {}) => {
+    await token.approve(htlc.address, tokenAmount, {from: sender})
+    return htlc.newContract(
+      receiver,
+      hashlock,
+      timelock,
+      token.address,
+      tokenAmount,
+      {
+        from: sender,
+      }
+    )
+  }
+
+  /*
+   * Helper for newContract() when expecting failure
+   */
+  const newContractExpectFailure = async (
+    shouldFailMsg,
+    expectedFailReason,
+    {
+      receiverAddr = receiver,
+      amount = tokenAmount,
+      timelock = timeLock1Hour,
+    } = {}
+  ) => {
+    try {
+      await htlc.newContract(
+        receiverAddr,
+        newSecretHashPair().hash,
+        timelock,
+        token.address,
+        amount,
+        {
+          from: sender,
+        }
+      )
+      assert.fail(shouldFailMsg)
+    } catch (err) {
+      assert.equal(err.message, REQUIRE_FAILED_MSG + expectedFailReason)
+    }
+  }
+})


### PR DESCRIPTION
adds a new function to peer called testContractState that converts the contract instance returned by getContract() into a javascript object. This object is then compared to an object representing the expected state of the HTLC. This expected state object is made right before testContractState is called. testContractState is called right after each call to newContract() or newERC20Contract() in client.js and manager.js

This PR also includes commits to add a .gitignore (which will prevent all the node_modules from syncing with GitHub) and 3 files (main1.js, main2.js, main3.js) that I found helpful for development purposes. When run sequentially in separate terminals, they execute a sample transaction without requiring you to manually enter pks, ports etc. via CLI 